### PR TITLE
Ignore comments in HTML

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -134,7 +134,8 @@ export function fastreadifyPage() {
     }
 
     function fastreadifyNode(node) {
-      if (node.tagName === 'SCRIPT' || node.tagName === 'STYLE') return;
+      console.log(node.tagName);
+      if (node.tagName === 'SCRIPT' || node.tagName === 'STYLE' || node.nodeType === 8) return;
       if ((node.childNodes == undefined) || (node.childNodes.length == 0)) {
         if ((node.textContent != undefined) && (node.tagName == undefined)) {
           var newNode = document.createElement('span');
@@ -171,4 +172,3 @@ export function patternsInclude(patterns, url){
   }
   return false;
 }
-

--- a/utils.js
+++ b/utils.js
@@ -134,7 +134,6 @@ export function fastreadifyPage() {
     }
 
     function fastreadifyNode(node) {
-      console.log(node.tagName);
       if (node.tagName === 'SCRIPT' || node.tagName === 'STYLE' || node.nodeType === 8) return;
       if ((node.childNodes == undefined) || (node.childNodes.length == 0)) {
         if ((node.textContent != undefined) && (node.tagName == undefined)) {


### PR DESCRIPTION
Fixes #6 
Currently, fastread edits the comments on the page and makes them visible. This fixes that by placing a check for the nodeType (8 for comments).